### PR TITLE
fix:buid sync_async folder 

### DIFF
--- a/semana_3/CMakeLists.txt
+++ b/semana_3/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(TCP)
 add_subdirectory(UDP)
+add_subdirectory(SYNC_ASYNC)

--- a/semana_3/SYNC_ASYNC/async_srv.c
+++ b/semana_3/SYNC_ASYNC/async_srv.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/semana_3/SYNC_ASYNC/sync_srv.c
+++ b/semana_3/SYNC_ASYNC/sync_srv.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
## About
Fix buid error(cmake) in  sync_async folder and add bzero() header(strings.h)

### Obs:
I know that this library (strings.h) is considered legacy. But as it is an example and it will be run on a computer (I don't need to worry about maximum portability) I preferred to leave it. If you want to run on different OS, just create a container.